### PR TITLE
[fix]: isMovable 속성 프론트와 변수명 오타로 인해 달라서 JsonProperty 지정

### DIFF
--- a/src/main/java/com/douzone/surveymanagement/selection/dto/reqeust/SelectionCreateDto.java
+++ b/src/main/java/com/douzone/surveymanagement/selection/dto/reqeust/SelectionCreateDto.java
@@ -25,6 +25,7 @@ public class SelectionCreateDto {
     @Length(min = 1, max = 255, message = "선택지 내용은 최소 1자보다 크고 255자 보다 작아야 합니다.")
     private String selectionValue;
 
+    @JsonProperty("isMoveable")
     @NotNull(message = "이동 여부는 null일 수 없습니다.")
     private boolean isMovable;
 


### PR DESCRIPTION
## Content
1. 프론트에서 보내는 isMovable 변수명과 백에서 받는 isMovable 변수명의 불일치 (프론트쪽 오타)로 인핸 `JsonProperty`를 지정하여 해결했습니다.