### PR TITLE
HOTFIX: 프론트 배포 서버 CORS Origin 추가

### DIFF
--- a/src/main/java/com/douzone/surveymanagement/common/security/SecurityConfig.java
+++ b/src/main/java/com/douzone/surveymanagement/common/security/SecurityConfig.java
@@ -64,7 +64,9 @@ public class SecurityConfig {
     @Bean
     CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+        configuration.setAllowedOrigins(
+            List.of("http://localhost:3000", "https://survey-management-frontend.vercel.app/")
+        );
         configuration.setAllowedMethods(List.of("*"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowedOriginPatterns(List.of("*"));


### PR DESCRIPTION
## Content
1. 백엔드 CORS 설정에 프론트 배포 도메인을 추가 했습니다.
